### PR TITLE
fix(client): honor ConnectionConfig fields; deprecate unsupported knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ConnectionConfig` fields now honored** (`turul-mcp-client`): `HttpTransport::with_config` previously advertised six configuration fields but consumed only three (`user_agent`, `follow_redirects`, `headers`). `max_redirects`, `pool_settings.max_idle_per_host`, and `pool_settings.idle_timeout` were silent no-ops — callers set them and `reqwest` defaults applied instead. These three are now wired through to `reqwest::ClientBuilder` (`Policy::limited`, `pool_max_idle_per_host`, `pool_idle_timeout`).
+
+### Deprecated
+
+- **`ConnectionConfig::keep_alive`** and **`PoolConfig::max_lifetime`** (`turul-mcp-client`): no reqwest equivalent. `reqwest` exposes `tcp_keepalive(Option<Duration>)`, not a boolean, and has no per-connection max-lifetime API. Both fields will be removed in 0.4. Callers who do not reference them are unaffected.
+
+### Changed
+
+- **`PoolConfig::default().max_idle_per_host`** raised from 5 to 32 (`turul-mcp-client`): the previous default was silently ignored (reqwest's internal default `usize::MAX` applied). Now that the field is honored, the previous default would cap callers at 5 idle connections per host — a regression for fan-out workloads. 32 matches typical HTTP client sizing; callers can still set their own value.
+
+### Note
+
+This release fixes `ConnectionConfig` API truthfulness only. It does not change HTTP/2 support, connection protocol negotiation, or any other transport-layer behavior. A separate investigation (#13) is evaluating whether enabling `reqwest/http2` measurably affects cold-path tail latency; no decision has been made on that feature.
+
 ## [0.3.34] - 2026-04-21
 
 ### Fixed

--- a/crates/turul-mcp-client/src/config.rs
+++ b/crates/turul-mcp-client/src/config.rs
@@ -101,10 +101,17 @@ pub struct ConnectionConfig {
     /// Whether to follow redirects
     pub follow_redirects: bool,
 
-    /// Maximum number of redirects to follow
+    /// Maximum number of redirects to follow (only applies when `follow_redirects = true`)
     pub max_redirects: u32,
 
-    /// Keep-alive settings
+    /// Keep-alive settings.
+    ///
+    /// No reqwest equivalent — reqwest exposes `tcp_keepalive(Option<Duration>)`, not a
+    /// boolean. This field is scheduled for removal in 0.4.
+    #[deprecated(
+        since = "0.3.35",
+        note = "no reqwest equivalent; scheduled for removal in 0.4"
+    )]
     pub keep_alive: bool,
 
     /// Connection pool settings
@@ -114,14 +121,27 @@ pub struct ConnectionConfig {
 /// Connection pool configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
-    /// Maximum number of idle connections per host
+    /// Maximum number of idle connections per host kept in the pool.
+    ///
+    /// Wired to `reqwest::ClientBuilder::pool_max_idle_per_host`. The default was raised
+    /// from 5 to 32 in 0.3.35 so that callers relying on the previous default (which was
+    /// silently ignored and deferred to reqwest's internal default) are not regressed.
     pub max_idle_per_host: u32,
 
-    /// Idle connection timeout
+    /// Idle connection timeout.
+    ///
+    /// Wired to `reqwest::ClientBuilder::pool_idle_timeout`.
     #[serde(with = "duration_serde")]
     pub idle_timeout: Duration,
 
-    /// Connection lifetime
+    /// Maximum connection lifetime.
+    ///
+    /// No reqwest equivalent — reqwest exposes `pool_idle_timeout` but no per-connection
+    /// max lifetime. This field is scheduled for removal in 0.4.
+    #[deprecated(
+        since = "0.3.35",
+        note = "no reqwest equivalent; scheduled for removal in 0.4"
+    )]
     #[serde(with = "duration_serde")]
     pub max_lifetime: Duration,
 }
@@ -183,6 +203,7 @@ impl Default for RetryConfig {
 }
 
 impl Default for ConnectionConfig {
+    #[allow(deprecated)] // keep_alive is deprecated but must remain in Default until 0.4
     fn default() -> Self {
         Self {
             user_agent: Some(format!("mcp-client/{}", env!("CARGO_PKG_VERSION"))),
@@ -196,9 +217,13 @@ impl Default for ConnectionConfig {
 }
 
 impl Default for PoolConfig {
+    #[allow(deprecated)] // max_lifetime is deprecated but must remain in Default until 0.4
     fn default() -> Self {
         Self {
-            max_idle_per_host: 5,
+            // 32 matches typical HTTP client pool sizing. Previously 5, silently ignored
+            // (reqwest default was `usize::MAX`). 0.3.35 honors the value, so raising the
+            // default here avoids regressing callers who took the previous default.
+            max_idle_per_host: 32,
             idle_timeout: Duration::from_secs(90),
             max_lifetime: Duration::from_secs(300),
         }

--- a/crates/turul-mcp-client/src/transport/http.rs
+++ b/crates/turul-mcp-client/src/transport/http.rs
@@ -94,11 +94,17 @@ impl HttpTransport {
 
         let mut builder = Client::builder()
             .timeout(Duration::from_secs(30))
-            .user_agent(user_agent);
+            .user_agent(user_agent)
+            .pool_max_idle_per_host(config.pool_settings.max_idle_per_host as usize)
+            .pool_idle_timeout(config.pool_settings.idle_timeout);
 
-        if !config.follow_redirects {
-            builder = builder.redirect(reqwest::redirect::Policy::none());
-        }
+        builder = if config.follow_redirects {
+            builder.redirect(reqwest::redirect::Policy::limited(
+                config.max_redirects as usize,
+            ))
+        } else {
+            builder.redirect(reqwest::redirect::Policy::none())
+        };
 
         if let Some(ref headers) = config.headers {
             let mut header_map = reqwest::header::HeaderMap::new();

--- a/crates/turul-mcp-client/tests/redirect_policy.rs
+++ b/crates/turul-mcp-client/tests/redirect_policy.rs
@@ -1,0 +1,72 @@
+//! Regression test: `ConnectionConfig.max_redirects` is honored.
+//!
+//! Before 0.3.35, `HttpTransport::with_config` ignored `max_redirects` entirely;
+//! reqwest fell back to its default redirect policy (10 hops). Clients that set
+//! `max_redirects = 0` expecting to see raw 3xx responses silently got auto-followed
+//! redirects instead.
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use turul_mcp_client::config::ConnectionConfig;
+use turul_mcp_client::transport::Transport;
+use turul_mcp_client::transport::http::HttpTransport;
+
+/// With `max_redirects = 0, follow_redirects = true`, a 302 must NOT be followed.
+/// The transport should surface the 3xx as an HTTP error (reqwest treats
+/// exceeded-redirect as an error) rather than chasing the Location header.
+#[tokio::test]
+async fn max_redirects_zero_does_not_follow_302() {
+    let mock_server = MockServer::start().await;
+
+    // POST /mcp → 302 redirect to /elsewhere
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with(
+            ResponseTemplate::new(302).insert_header("Location", "/elsewhere"),
+        )
+        .expect(1) // Must be called exactly once — no auto-follow
+        .mount(&mock_server)
+        .await;
+
+    // POST /elsewhere → 200 with a success body. If max_redirects were ignored,
+    // reqwest's default policy would follow the 302 here and we'd see this mock hit.
+    Mock::given(method("POST"))
+        .and(path("/elsewhere"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "application/json")
+                .set_body_json(serde_json::json!({
+                    "jsonrpc": "2.0", "id": "req_0", "result": {}
+                })),
+        )
+        .expect(0) // Must NOT be called — redirect should not be followed
+        .mount(&mock_server)
+        .await;
+
+    let config = ConnectionConfig {
+        follow_redirects: true,
+        max_redirects: 0,
+        ..Default::default()
+    };
+
+    let endpoint = format!("{}/mcp", mock_server.uri());
+    let transport = HttpTransport::with_config(&endpoint, &config).unwrap();
+    transport.connect().await.unwrap();
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "req_0",
+        "method": "ping",
+    });
+
+    // Expect an error (reqwest surfaces "too many redirects" when limit is exceeded
+    // on the very first hop). The exact error variant is not the point — the point
+    // is that the mock at /elsewhere is never hit. wiremock's `.expect(0)` / `.expect(1)`
+    // assertions on drop verify the hop count.
+    let _ = transport.send_request(request).await;
+
+    // wiremock verifies the expectations when `mock_server` drops, but surfacing any
+    // mismatch explicitly gives a better failure message.
+    mock_server.verify().await;
+}


### PR DESCRIPTION
## Summary

`ConnectionConfig` advertised six configuration fields but `HttpTransport::with_config` consumed only three. The other three were silent no-ops — callers set them and `reqwest` defaults applied instead. This PR honors the fields reqwest can express, and deprecates the fields it can't.

This is **Track A** of the v0.3.33 concurrent-client follow-up: **API truthfulness only, no performance claim**. See "Track B" below for the separate H2 hypothesis.

## What changed

### Honored (wired through to `reqwest::ClientBuilder` in `HttpTransport::with_config`)

| Field | reqwest method |
|---|---|
| `max_redirects` | `Policy::limited(n)` (when `follow_redirects=true`) |
| `pool_settings.max_idle_per_host` | `pool_max_idle_per_host(n)` |
| `pool_settings.idle_timeout` | `pool_idle_timeout(d)` |

### Deprecated (no reqwest equivalent; scheduled for removal in 0.4)

| Field | Why |
|---|---|
| `keep_alive: bool` | reqwest exposes `tcp_keepalive(Option<Duration>)`, not a boolean. A bool with unspecified duration is not a meaningful knob. |
| `pool_settings.max_lifetime` | reqwest has no per-connection max-lifetime API. Honoring would require custom client rotation machinery (forbidden by repo complexity rules). |

Both carry `#[deprecated(since = "0.3.35", note = "no reqwest equivalent; scheduled for removal in 0.4")]`.

### Default change

`PoolConfig::default().max_idle_per_host` raised from 5 to 32. Previously this was silently ignored and reqwest's internal default (`usize::MAX`) applied. Now that it's honored, the previous default of 5 would cap existing callers at 5 idle connections — a regression for any fan-out workload. 32 matches typical HTTP client sizing; callers can still set their own value.

## Tests

New `tests/redirect_policy.rs`:
- Construct `HttpTransport` with `max_redirects = 0, follow_redirects = true`
- Mock server returns 302 with `Location: /elsewhere`
- Assert: the 302 endpoint is called **exactly once**, and `/elsewhere` is called **exactly zero times**

Clean and deterministic — observes the redirect policy on the wire, no timing dependency.

Automated tests for `pool_max_idle_per_host` / `pool_idle_timeout` are deliberately **not** included: `reqwest::Client` is opaque and has no inspection API for its internal pool config. Per codex feedback, attempting to verify pool behavior via connection-timing observation would be flaky and misleading. Coverage for those fields is via code review, the docstring on `PoolConfig`, and the deterministic `with_config` plumbing path.

## What this PR does NOT claim

This PR **does not** claim to fix cold-path fan-out tail latency against production MCP backends. The leading hypothesis (reqwest's `http2` feature being off in the workspace) is a separate investigation — see Track B below. No performance numbers are attached to this change.

## Track B (separate investigation, not in this PR)

Filed as: #13

Validate whether enabling `reqwest/http2` measurably reduces cold-path tail latency:
1. Capability probe: confirm real backends (e.g. `st.aussierobots.com.au`) negotiate H2 via ALPN (`curl --http2 -v`, `openssl s_client -alpn h2`).
2. Controlled measurement: local H2 test server, fan out N ≥ 4 concurrent calls, compare connection count and p50/p99 latency with and without `reqwest/http2`.
3. Only if (1) and (2) both confirm: open a second PR enabling the feature with the measurement as the test evidence in the same change.

## Test plan

- [x] `cargo test -p turul-mcp-client` — all 16 tests pass, including new `redirect_policy`
- [x] `cargo check --workspace` — no new warnings
- [x] Verified no workspace consumers reference the deprecated fields (`keep_alive`, `max_lifetime`) — grep of `crates/` and `examples/` finds only unrelated matches (SQLx `max_lifetime`, SSE `send_keep_alive`)
- [ ] CI green
