### PR TITLE
Update Turul MCP skills for v0.6.3

### DIFF
--- a/plugins/turul-mcp-skills/.claude-plugin/plugin.json
+++ b/plugins/turul-mcp-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "turul-mcp-skills",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Skills and tools for building MCP servers and clients with the Turul MCP Framework (Rust). Guides tool creation, resource/prompt patterns, output schemas, client patterns, middleware, error handling, task support, Lambda deployment, testing, elicitation, session storage, storage backend selection, authentication/authorization (OAuth 2.1 RS, JWT, API key), authorization server patterns (demo PKCE, JWKS, DCR), project scaffolding, and validation.",
   "author": {
     "name": "Aussie Robots",

--- a/plugins/turul-mcp-skills/README.md
+++ b/plugins/turul-mcp-skills/README.md
@@ -2,7 +2,7 @@
 
 Skills and tools for building MCP servers and clients with the [Turul MCP Framework](https://github.com/aussierobots/turul-mcp-framework) (Rust).
 
-## What's Included (v0.6.2)
+## What's Included (v0.6.3)
 
 | Component | Type | Purpose |
 |---|---|---|
@@ -219,6 +219,23 @@ Validates an existing Turul MCP server project:
 This plugin targets **turul-mcp-server v0.3** (MCP 2025-11-25).
 
 ## Changelog
+
+### v0.6.3
+- **Fixed**: `task-patterns` dead constructors — `SqliteTaskStorage::new("…")`, `PostgresTaskStorage::new("…")`, `DynamoDbTaskStorage::new("…")` did not compile against the current API. All three now use `with_config(<BackendConfig>{...})` form, matching `lambda-deployment`. Also corrected the stale "auto-creates tables on connect" note in `references/task-storage-guide.md` (tables are migrated only when `verify_tables = true`).
+- **Fixed**: `x-authorizer-principalid` examples in `auth-patterns`, `middleware-patterns`, `lambda-deployment` (SKILL.md + reference + 2 example .rs files). The Lambda adapter intentionally skips API Gateway internals (`principalId`, `integrationLatency`, `usageIdentifierKey`); examples now use concrete custom-context fields (`x-authorizer-user_id`, `x-authorizer-account_id`, `x-authorizer-scope`) with an explicit "not forwarded" note.
+- **Added**: `mcp-client-patterns` — new "Bearer Lifecycle & Rotation" section covering `set_bearer()` (v0.3.44), idempotent `disconnect()`/`Drop` (v0.3.43), SSE GET 4xx terminal behavior (v0.3.38), concurrent `call_tool` via `&self` transport (v0.3.33), and the MCP requirement that bearer auth is present on every HTTP request including GET listeners and DELETE cleanup.
+- **Added**: `auth-patterns` — new "Authorization Server Discovery Chain (RFC 8414)" section spelling out the RS PRM → `authorization_servers` → AS metadata fetch flow, with explicit "the RS does NOT serve `/.well-known/oauth-authorization-server`" guidance and quoted MCP 2025-11-25 normative MUSTs.
+- **Added**: `auth-patterns` — new "Resource Parameter (RFC 8707)" section covering the client-side MCP MUST that `resource` is included in both `/authorize` and `/token` requests, and the corresponding RS implementer responsibilities (canonical URI alignment between `ProtectedResourceMetadata::new`, `JwtValidator::new`, and what clients send).
+- **Added**: `auth-patterns` — two new "Common Mistakes" entries: resource/audience URI mismatch (the most common interop failure) and the RS-vs-AS discovery boundary.
+- **Added**: 7 frontmatter `Do NOT use for ...` disambiguation clauses to reduce trigger collisions:
+  - `auth-patterns` ↔ `authorization-server-patterns` (validate-vs-issue boundary)
+  - `task-patterns` ↔ `session-storage-backends` (reciprocal — TaskStorage ≠ SessionStorage)
+  - `testing-patterns` ↔ `mcp-client-patterns` (test harness vs production client)
+  - `middleware-patterns` ↔ `auth-patterns` (plumbing vs OAuth specifics)
+  - `mcp-client-patterns` (client-side vs server-side scope)
+  - `authorization-server-patterns` (tightened to "demo examples are not production identity infrastructure" per spec)
+- **Verified**: smoke-tested 5 skill patterns in a throwaway crate (`/tmp/turul-skills-smoke`) — `echo_text`, `add_numbers`, `server_time_stub` (function macro), `WordCountTool` (derive + `output = Type` + schemars), `slow_add` (function macro + `task_support = "optional"`), plus `InMemoryTaskStorage::new()` — all compile cleanly against current crate APIs. No production examples touched.
+- **Scope**: skills-only release. Framework crates were not modified; status-code teaching unchanged.
 
 ### v0.6.2
 - Added server identity (icons) section to `tool-creation-patterns` skill with `.icons()` builder method, `Icon::data_uri()`, and trigger phrases

--- a/plugins/turul-mcp-skills/skills/auth-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/auth-patterns/SKILL.md
@@ -12,7 +12,8 @@ description: >
   Covers authentication and authorization patterns for MCP servers
   in the Turul MCP Framework (Rust): OAuth 2.1 Resource Server
   compliance, JWT validation, API key middleware, and Lambda
-  authorizer integration.
+  authorizer integration. Do NOT use for issuing tokens or
+  building an Authorization Server — see authorization-server-patterns.
 ---
 
 # Auth Patterns — Turul MCP Framework
@@ -148,6 +149,34 @@ let metadata = ProtectedResourceMetadata::new(
 
 The handler returns JSON with `Cache-Control: public, max-age=3600`.
 
+## Authorization Server Discovery Chain (RFC 8414)
+
+The RS publishes the AS URL via PRM; clients then fetch the AS metadata themselves. **The RS does NOT serve `/.well-known/oauth-authorization-server` — that endpoint lives on the AS.**
+
+```
+                                                AS
+   Client                                       │
+     │   1. GET /.well-known/                   │
+     │      oauth-protected-resource    ───► RS │
+     │                                          │
+     │   2. Reads "authorization_servers" ──────│──►  (URL of the AS)
+     │                                          │
+     │   3. GET /.well-known/                                ▼
+     │      oauth-authorization-server  ──────────────►  RFC 8414
+     │      (or .../openid-configuration)                AS metadata
+     │
+     │   4. Run PKCE flow against AS, then call RS with bearer
+```
+
+**Normative requirements** (MCP 2025-11-25 § Authorization):
+
+- "MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata (RFC 9728)" — the RS publishes its identity and the AS list.
+- "MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery."
+- "MCP authorization servers **MUST** provide at least one of: OAuth 2.0 Authorization Server Metadata (RFC 8414) or OpenID Connect Discovery 1.0."
+- "MCP clients **MUST** support both discovery mechanisms."
+
+The RS implementer's job stops at point 2: publish a truthful `authorization_servers` list in PRM and ensure your `resource` URL matches what clients will send.
+
 ## Audience Validation
 
 Audience validation is **always required** — there's no opt-out.
@@ -160,6 +189,42 @@ let validator = JwtValidator::new(jwks_uri, "my-audience");  // NOT Option<&str>
 With `oauth_resource_server()`, the audience is automatically set to the resource URL from your metadata. With manual construction, you choose any audience string.
 
 **Why mandatory**: Without audience validation, a token issued for `https://other-service.com` would be accepted by your MCP server. This is a critical security requirement per OAuth 2.1.
+
+## Resource Parameter (RFC 8707) — what clients must send
+
+Audience validation only works because clients are required to **bind** the token to your specific RS at the point of issuance. MCP makes this a normative client-side requirement.
+
+> MCP 2025-11-25 § Resource Parameter Implementation:
+> "MCP clients **MUST** implement Resource Indicators for OAuth 2.0 as defined in RFC 8707... The `resource` parameter:
+> 1. **MUST** be included in both authorization requests and token requests.
+> 2. **MUST** identify the MCP server that the client intends to use the token with..."
+>
+> "MCP clients **MUST** send this parameter regardless of whether authorization servers support it."
+
+Concretely, a compliant MCP client sends:
+
+```
+GET  /authorize?response_type=code
+                &client_id=...
+                &redirect_uri=...
+                &resource=https://api.example.com/mcp     ← MUST
+                &code_challenge=...&code_challenge_method=S256
+                &scope=mcp:read mcp:write
+
+POST /token     grant_type=authorization_code
+                &code=...
+                &resource=https://api.example.com/mcp     ← MUST (same value)
+                &code_verifier=...
+```
+
+The AS uses `resource` to set the token's `aud` claim. The RS later validates that `aud` equals its own canonical URI.
+
+**RS implementer responsibilities** (still small):
+
+1. Pick a single canonical resource URI for your MCP server (e.g. `https://api.example.com/mcp`).
+2. Pass that exact URI as the first argument to `ProtectedResourceMetadata::new(...)`.
+3. Pass that exact URI as the audience argument to `JwtValidator::new(...)` (or let `oauth_resource_server()` propagate it for you).
+4. Document the URI so client integrators know what to send as `resource` and `aud`.
 
 ## Accessing Auth Claims in Tools
 
@@ -271,16 +336,17 @@ impl McpMiddleware for ApiKeyMiddleware {
 
 ## Pattern 4: Lambda API Gateway Authorizer
 
-On Lambda, API Gateway can validate tokens before your MCP server runs. The authorizer populates `x-authorizer-*` headers automatically:
+On Lambda, API Gateway can validate tokens before your MCP server runs. The authorizer's **custom context fields** (whatever your authorizer Lambda returns under `context: {...}`) are forwarded as `x-authorizer-*` headers automatically:
 
 ```rust
-// Read authorizer claims in middleware or tools
+// Read authorizer claims in middleware or tools — use the custom fields
+// your authorizer returns, e.g. user_id, account_id, scope.
 let user_id = ctx.metadata()
-    .get("x-authorizer-principalid")
+    .get("x-authorizer-user_id")
     .and_then(|v| v.as_str());
 ```
 
-The Lambda adapter converts camelCase authorizer fields to snake_case headers (`userId` → `x-authorizer-user_id`). Both V1 (REST API) and V2 (HTTP API) formats are supported.
+The Lambda adapter converts camelCase authorizer fields to snake_case headers (`userId` → `x-authorizer-user_id`). Both V1 (REST API) and V2 (HTTP API) formats are supported. **Not forwarded**: API Gateway internals (`principalId`, `integrationLatency`, `usageIdentifierKey`) — surface your own `user_id`/`subject`/etc. from the authorizer's context instead.
 
 **When to use Gateway authorizers instead of `turul-mcp-oauth`:**
 - AWS-native deployments with Cognito or custom authorizers
@@ -379,6 +445,10 @@ When `scopes_supported` is configured, `scope="mcp:read mcp:write"` is included 
 6. **JWKS endpoint hammering** — The validator rate-limits refresh to once per 60s by default. If you set a very short refresh interval, you risk being rate-limited by the AS.
 
 7. **Manually dispatching well-known routes in `run_streaming_with()`** — You don't need custom dispatch for `.well-known` routes. Register them via `.route()` on `LambdaMcpServerBuilder` — `handle_streaming()` checks the route registry before MCP dispatch. Use `run_streaming_with()` only when you need pre-dispatch logic that isn't route-based (e.g., request logging, custom health checks).
+
+8. **Resource / audience URI mismatch between RS and what clients send** — The single most common interop failure. If your `ProtectedResourceMetadata::new("https://api.example.com/mcp", ...)` declares one URI but clients send `resource=https://api.example.com` (no `/mcp` path), the AS issues `aud=https://api.example.com` and your RS rejects with `invalid audience`. Fix: pick one canonical URI, use it verbatim in `ProtectedResourceMetadata::new`, `JwtValidator::new`, and document it so client integrators send the exact same string as `resource` in both `/authorize` and `/token`.
+
+9. **Expecting the RS to serve `/.well-known/oauth-authorization-server`** — That endpoint lives on the AS, not the RS. The RS only serves `/.well-known/oauth-protected-resource` (RFC 9728); it advertises the AS URL via the `authorization_servers` field and clients fetch RFC 8414 metadata from the AS directly.
 
 ## Beyond This Skill
 

--- a/plugins/turul-mcp-skills/skills/authorization-server-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/authorization-server-patterns/SKILL.md
@@ -9,7 +9,10 @@ description: >
   "refresh token", "authorization-server-patterns", or "build an auth server".
   Covers building a standalone demo OAuth 2.1 Authorization Server
   using standard Rust crates for use alongside Turul MCP Resource Servers.
-  Demo-grade only — not production identity infrastructure.
+  Use these demo examples only for local development and PoCs.
+  Do NOT use these demo examples as production identity infrastructure —
+  use Cognito, Auth0, Keycloak, or Ory Hydra for that. For protecting an
+  MCP server (RS role), see auth-patterns.
 ---
 
 # Authorization Server Patterns — Demo / Reference

--- a/plugins/turul-mcp-skills/skills/lambda-deployment/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/lambda-deployment/SKILL.md
@@ -264,15 +264,18 @@ tracing_subscriber::fmt()
 
 ## API Gateway Authorizer Integration
 
-API Gateway authorizers populate `x-authorizer-*` headers automatically. Middleware reads them via `ctx.metadata()`:
+API Gateway authorizers' **custom context fields** are forwarded as `x-authorizer-*` headers automatically. Middleware reads them via `ctx.metadata()` using the field name your authorizer returns:
 
 ```rust
 let user_id = ctx.metadata()
-    .get("x-authorizer-principalid")
+    .get("x-authorizer-user_id")
+    .and_then(|v| v.as_str());
+let account_id = ctx.metadata()
+    .get("x-authorizer-account_id")
     .and_then(|v| v.as_str());
 ```
 
-The Lambda adapter converts camelCase authorizer fields to snake_case headers (`userId` → `x-authorizer-user_id`). Both V1 (REST API) and V2 (HTTP API) formats are supported.
+The Lambda adapter converts camelCase authorizer fields to snake_case headers (`userId` → `x-authorizer-user_id`). Both V1 (REST API) and V2 (HTTP API) formats are supported. **Not forwarded** (API Gateway internals, intentionally skipped): `principalId`, `integrationLatency`, `usageIdentifierKey` — make sure your authorizer returns the identity fields you need under `context: {...}`.
 
 **See:** the `middleware-patterns` skill (Pattern 4: Lambda Auth) for the full `LambdaAuthMiddleware` example.
 

--- a/plugins/turul-mcp-skills/skills/lambda-deployment/examples/lambda-production-config.rs
+++ b/plugins/turul-mcp-skills/skills/lambda-deployment/examples/lambda-production-config.rs
@@ -43,14 +43,17 @@ impl McpMiddleware for LambdaAuthMiddleware {
             return Ok(());
         }
 
-        // API Gateway authorizer populates x-authorizer-* headers
+        // API Gateway authorizer's custom context fields land as x-authorizer-*
+        // headers. Use whatever identity field your authorizer Lambda returns
+        // (e.g. user_id, sub, account_id). `principalId` is NOT forwarded — it
+        // is filtered out as an API Gateway internal.
         let user_id = ctx
             .metadata()
-            .get("x-authorizer-principalid")
+            .get("x-authorizer-user_id")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
                 MiddlewareError::unauthenticated(
-                    "Missing authorizer principal — is the API Gateway authorizer configured?",
+                    "Missing authorizer user_id — is your API Gateway authorizer returning it under context?",
                 )
             })?;
 

--- a/plugins/turul-mcp-skills/skills/mcp-client-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/mcp-client-patterns/SKILL.md
@@ -9,7 +9,9 @@ description: >
   "refresh_tools", "tool change notification", or "list_changed client".
   Covers transport selection, connection lifecycle, tool/resource/prompt
   invocation, task workflows, tool change notifications, and error handling
-  for the Turul MCP Client (turul-mcp-client crate, Rust).
+  for the Turul MCP Client (turul-mcp-client crate, Rust). Do NOT use for
+  server-side work (tools, resources, prompts) — see tool-creation-patterns
+  and resource-prompt-patterns.
 ---
 
 # Turul MCP Client Patterns
@@ -286,6 +288,38 @@ This skill covers transport and lifecycle, not authentication. MCP clients that 
 The `turul-mcp-client` crate handles transport and session lifecycle. Token acquisition and header injection are the client application's responsibility.
 
 **See:** the `auth-patterns` skill for RS-side validation and the `authorization-server-patterns` skill for building a demo AS to test against.
+
+## Bearer Lifecycle & Rotation
+
+Per MCP authorization, the bearer token MUST be present on **every** HTTP request a client makes — that includes the POST request stream, the GET SSE listener, and the DELETE cleanup. A long-lived client that holds a token across rotations needs to swap the token in place rather than rebuild the whole client (which would drop the connection pool).
+
+```rust
+// turul-mcp-client v0.3
+// Rotate the bearer on a long-lived client without losing the connection pool.
+// All five outbound surfaces (POST, GET SSE, DELETE, send_request_with_headers,
+// send_notification) pick up the new token immediately.
+client.set_bearer(Some(&fresh_token)).await;
+client.disconnect().await?;  // DELETE goes out with the fresh bearer
+```
+
+**Lifecycle invariants worth knowing** (v0.3.33–v0.3.46 hardening):
+
+| Invariant | Notes |
+|---|---|
+| `disconnect()` is idempotent | Safe to call multiple times; also fires implicitly from `Drop`. After explicit `disconnect()`, the implicit `Drop` is a no-op (no duplicate DELETE). |
+| Concurrent `call_tool` on `Arc<McpClient>` runs in parallel | `Transport` trait takes `&self` on hot paths; reqwest's connection pool serves concurrent requests. No outer `Mutex`. |
+| SSE GET 4xx is terminal | The background SSE listener treats any 4xx on the GET stream as a permanent failure, clears the cached session ID, and exits. The next `connect()` re-establishes from a fresh `initialize`. |
+| `set_bearer(None)` falls back to default headers | Useful for clearing an override and reverting to whatever was baked into `ClientBuilder::default_headers()`. |
+
+Common rotation pattern for OAuth `client_credentials` deployments:
+
+```rust
+loop {
+    let token = oauth.refresh().await?;     // get fresh bearer
+    client.set_bearer(Some(&token)).await;  // swap in place
+    tokio::time::sleep(token.ttl - skew).await;
+}
+```
 
 ## Beyond This Skill
 

--- a/plugins/turul-mcp-skills/skills/middleware-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/middleware-patterns/SKILL.md
@@ -9,6 +9,9 @@ description: >
   "lambda auth middleware", or "DispatcherResult".
   Covers creating HTTP middleware for auth, rate limiting, logging,
   and Lambda authorizer extraction in the Turul MCP Framework (Rust).
+  For OAuth/JWT-specific middleware (oauth_resource_server,
+  JwtValidator, ProtectedResourceMetadata) see auth-patterns —
+  this skill covers the McpMiddleware trait plumbing only.
 ---
 
 # Middleware Patterns — Turul MCP Framework
@@ -249,12 +252,15 @@ impl McpMiddleware for LambdaAuthMiddleware {
             return Ok(());
         }
 
-        // API Gateway authorizer populates x-authorizer-* headers
+        // API Gateway authorizer's custom context fields land as x-authorizer-*
+        // headers. Use the field name your authorizer Lambda returns under
+        // `context: {...}` (e.g. user_id, sub, account_id). `principalId` is
+        // intentionally NOT forwarded — return your own identity field instead.
         let user_id = ctx.metadata()
-            .get("x-authorizer-principalid")
+            .get("x-authorizer-user_id")
             .and_then(|v| v.as_str())
             .ok_or_else(|| MiddlewareError::unauthenticated(
-                "Missing authorizer principal — is the API Gateway authorizer configured?"
+                "Missing authorizer user_id — is the API Gateway authorizer returning it in context?"
             ))?;
 
         injection.set_state("user_id", serde_json::json!(user_id));

--- a/plugins/turul-mcp-skills/skills/middleware-patterns/examples/lambda-auth-middleware.rs
+++ b/plugins/turul-mcp-skills/skills/middleware-patterns/examples/lambda-auth-middleware.rs
@@ -21,15 +21,18 @@ impl McpMiddleware for LambdaAuthMiddleware {
             return Ok(());
         }
 
-        // API Gateway Lambda authorizer populates x-authorizer-* headers.
-        // These are pre-validated by the authorizer — middleware just extracts them.
-        let principal_id = ctx
+        // API Gateway Lambda authorizer forwards its custom context fields as
+        // x-authorizer-* headers (snake_cased). Use the fields YOUR authorizer
+        // Lambda returns under `context: {...}` — for example, user_id, sub,
+        // account_id, scope. `principalId` is intentionally NOT forwarded
+        // (it's an API Gateway internal); return your own identity field.
+        let user_id = ctx
             .metadata()
-            .get("x-authorizer-principalid")
+            .get("x-authorizer-user_id")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
                 MiddlewareError::unauthenticated(
-                    "Missing authorizer principal — is the API Gateway authorizer configured?",
+                    "Missing authorizer user_id — is your API Gateway authorizer returning it under context?",
                 )
             })?;
 
@@ -41,7 +44,7 @@ impl McpMiddleware for LambdaAuthMiddleware {
             .unwrap_or("default");
 
         // Inject into session for tool access
-        injection.set_state("user_id", json!(principal_id));
+        injection.set_state("user_id", json!(user_id));
         injection.set_state("scope", json!(scope));
         injection.set_metadata("auth_source", json!("api-gateway-authorizer"));
 

--- a/plugins/turul-mcp-skills/skills/middleware-patterns/references/middleware-trait-guide.md
+++ b/plugins/turul-mcp-skills/skills/middleware-patterns/references/middleware-trait-guide.md
@@ -81,8 +81,12 @@ For HTTP transport:
 - `"x-forwarded-for"` — Client IP (behind proxy)
 
 For Lambda transport:
-- `"x-authorizer-principalid"` — API Gateway authorizer principal
-- `"x-authorizer-*"` — Authorizer context fields
+- `"x-authorizer-<field>"` — Authorizer's custom context fields, snake-cased
+  (e.g. `x-authorizer-user_id`, `x-authorizer-account_id`, `x-authorizer-scope`).
+  Use the field names your authorizer Lambda returns under `context: {...}`.
+- **Not forwarded**: API Gateway internals (`principalId`, `integrationLatency`,
+  `usageIdentifierKey`) are intentionally skipped — return your own identity
+  fields from the authorizer instead.
 - `"source-ip"` — API Gateway source IP
 
 ## SessionInjection

--- a/plugins/turul-mcp-skills/skills/session-storage-backends/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/session-storage-backends/SKILL.md
@@ -9,7 +9,8 @@ description: >
   "session event management", "SseEvent", or "SessionStorageError".
   Covers the SessionStorage trait, backend selection, event management
   for SSE resumability, error types, and background cleanup in the
-  Turul MCP Framework (Rust).
+  Turul MCP Framework (Rust). Do NOT use for TaskStorage — task
+  persistence is a separate trait; see task-patterns.
 ---
 
 # Session Storage Backends — Turul MCP Framework

--- a/plugins/turul-mcp-skills/skills/task-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/task-patterns/SKILL.md
@@ -12,7 +12,8 @@ description: >
   or "task storage backend".
   Covers MCP task support for long-running tools, state machine,
   storage backends, cancellation, and capability truthfulness in
-  the Turul MCP Framework (Rust).
+  the Turul MCP Framework (Rust). TaskStorage is distinct from
+  SessionStorage; for session persistence see session-storage-backends.
 ---
 
 # Task Patterns — Turul MCP Framework
@@ -153,17 +154,34 @@ use turul_mcp_task_storage::InMemoryTaskStorage;
 let storage = Arc::new(InMemoryTaskStorage::new());
 
 // SQLite (feature = "sqlite")
-use turul_mcp_task_storage::SqliteTaskStorage;
-let storage = Arc::new(SqliteTaskStorage::new("sqlite://tasks.db").await?);
+use turul_mcp_task_storage::{SqliteTaskStorage, SqliteTaskConfig};
+let storage = Arc::new(
+    SqliteTaskStorage::with_config(SqliteTaskConfig {
+        database_path: "tasks.db".into(),
+        ..Default::default()
+    }).await?,
+);
 
 // PostgreSQL (feature = "postgres")
-use turul_mcp_task_storage::PostgresTaskStorage;
-let storage = Arc::new(PostgresTaskStorage::new("postgres://localhost/mydb").await?);
+use turul_mcp_task_storage::{PostgresTaskStorage, PostgresTaskConfig};
+let storage = Arc::new(
+    PostgresTaskStorage::with_config(PostgresTaskConfig {
+        database_url: "postgres://localhost/mydb".into(),
+        ..Default::default()
+    }).await?,
+);
 
 // DynamoDB (feature = "dynamodb")
-use turul_mcp_task_storage::DynamoDbTaskStorage;
-let storage = Arc::new(DynamoDbTaskStorage::new("mcp-tasks").await?);
+use turul_mcp_task_storage::{DynamoDbTaskStorage, DynamoDbTaskConfig};
+let storage = Arc::new(
+    DynamoDbTaskStorage::with_config(DynamoDbTaskConfig {
+        table_name: "mcp-tasks".into(),
+        ..Default::default()
+    }).await?,
+);
 ```
+
+Each backend exposes `new()` (zero-arg, uses `<Backend>TaskConfig::default()`) and `with_config(...)` for explicit configuration. Use `with_config` whenever you need a non-default value — there is no string-URL constructor.
 
 **For full backend configuration details**, see the `storage-backend-matrix` reference.
 

--- a/plugins/turul-mcp-skills/skills/task-patterns/references/task-storage-guide.md
+++ b/plugins/turul-mcp-skills/skills/task-patterns/references/task-storage-guide.md
@@ -155,12 +155,17 @@ turul-mcp-task-storage = { version = "0.3", features = ["sqlite"] }
 ```
 
 ```rust
-use turul_mcp_task_storage::SqliteTaskStorage;
-let storage = Arc::new(SqliteTaskStorage::new("sqlite://tasks.db").await?);
+use turul_mcp_task_storage::{SqliteTaskStorage, SqliteTaskConfig};
+let storage = Arc::new(
+    SqliteTaskStorage::with_config(SqliteTaskConfig {
+        database_path: "tasks.db".into(),
+        ..Default::default()
+    }).await?,
+);
 ```
 
 - Persistent, single-instance only
-- Auto-creates tables on connect
+- Tables are auto-migrated only when `verify_tables = true` (defaults to `false`); for first-time use set both `verify_tables: true` and `create_tables: true`
 
 ### PostgreSQL (feature = "postgres")
 
@@ -170,12 +175,17 @@ turul-mcp-task-storage = { version = "0.3", features = ["postgres"] }
 ```
 
 ```rust
-use turul_mcp_task_storage::PostgresTaskStorage;
-let storage = Arc::new(PostgresTaskStorage::new("postgres://localhost/mydb").await?);
+use turul_mcp_task_storage::{PostgresTaskStorage, PostgresTaskConfig};
+let storage = Arc::new(
+    PostgresTaskStorage::with_config(PostgresTaskConfig {
+        database_url: "postgres://localhost/mydb".into(),
+        ..Default::default()
+    }).await?,
+);
 ```
 
 - Persistent, multi-instance safe (optimistic locking via `version` column)
-- Auto-creates tables on connect
+- Tables are auto-migrated only when `verify_tables = true` (defaults to `false`); for first-time use set both `verify_tables: true` and `create_tables: true`
 
 ### DynamoDB (feature = "dynamodb")
 
@@ -185,8 +195,13 @@ turul-mcp-task-storage = { version = "0.3", features = ["dynamodb"] }
 ```
 
 ```rust
-use turul_mcp_task_storage::DynamoDbTaskStorage;
-let storage = Arc::new(DynamoDbTaskStorage::new("mcp-tasks").await?);
+use turul_mcp_task_storage::{DynamoDbTaskStorage, DynamoDbTaskConfig};
+let storage = Arc::new(
+    DynamoDbTaskStorage::with_config(DynamoDbTaskConfig {
+        table_name: "mcp-tasks".into(),
+        ..Default::default()
+    }).await?,
+);
 ```
 
 - Persistent, serverless-native, multi-instance safe

--- a/plugins/turul-mcp-skills/skills/testing-patterns/SKILL.md
+++ b/plugins/turul-mcp-skills/skills/testing-patterns/SKILL.md
@@ -8,7 +8,9 @@ description: >
   "cargo test", "test organization", "SSE testing",
   or "test consolidation". Covers unit testing, E2E testing,
   compliance testing, SSE testing, and test organization
-  in the Turul MCP Framework (Rust).
+  in the Turul MCP Framework (Rust). McpTestClient is the
+  in-process test harness; for the production client API
+  see mcp-client-patterns.
 ---
 
 # Testing Patterns — Turul MCP Framework


### PR DESCRIPTION
## Scope

**Skills-only release.** No `turul-mcp-framework` crate changes, no framework tests touched, no `CLAUDE.md` framework status-code guidance edited. 14 files modified, all under `plugins/turul-mcp-skills/`.

Commit: `ae49e8c` — *"Update Turul MCP skills for v0.6.3"*.

## Changes

- **Fixed**: `task-patterns` dead constructors — `SqliteTaskStorage::new("…")`, `PostgresTaskStorage::new("…")`, `DynamoDbTaskStorage::new("…")` did not compile against the current API. All three now use `with_config(<BackendConfig>{...})` form, matching the canonical pattern in `lambda-deployment`. Also corrected a stale "auto-creates tables on connect" note in `references/task-storage-guide.md` (tables are migrated only when `verify_tables = true`).
- **Fixed**: removed all `x-authorizer-principalid` references from `auth-patterns`, `middleware-patterns`, `lambda-deployment` (SKILL.md + reference + 2 example `.rs` files). The Lambda adapter intentionally skips API Gateway internals (`principalId`, `integrationLatency`, `usageIdentifierKey`); examples now use concrete custom-context fields (`x-authorizer-user_id`, `x-authorizer-account_id`, `x-authorizer-scope`) with an explicit "not forwarded" note.
- **Added**: `mcp-client-patterns` — new *Bearer Lifecycle & Rotation* section covering `set_bearer()` (v0.3.44), idempotent `disconnect()`/`Drop` (v0.3.43), SSE GET 4xx terminal behavior (v0.3.38), concurrent `call_tool` via `&self` transport (v0.3.33), and the MCP requirement that bearer auth is present on every HTTP request including GET listeners and DELETE cleanup.
- **Added**: `auth-patterns` — new *Authorization Server Discovery Chain (RFC 8414)* section spelling out the RS PRM → `authorization_servers` → AS metadata fetch flow with explicit "the RS does NOT serve `/.well-known/oauth-authorization-server`" guidance and quoted MCP 2025-11-25 normative MUSTs.
- **Added**: `auth-patterns` — new *Resource Parameter (RFC 8707)* section covering the client-side MCP MUST that `resource` is included in both `/authorize` and `/token` requests, plus the corresponding RS implementer responsibilities (canonical URI alignment between `ProtectedResourceMetadata::new`, `JwtValidator::new`, and what clients send).
- **Added**: `auth-patterns` — two new *Common Mistakes* entries (resource/audience URI mismatch, and the RS-vs-AS discovery boundary).
- **Added**: 7 frontmatter `Do NOT use for ...` disambiguation clauses to reduce trigger collisions across `auth-patterns`, `authorization-server-patterns`, `task-patterns`, `session-storage-backends` (reciprocal), `testing-patterns`, `middleware-patterns`, `mcp-client-patterns`.
- **Bumped**: plugin `0.6.2 → 0.6.3` (`plugin.json` + README header + changelog entry).

## Validation

| Check | Result |
|---|---|
| Frontmatter YAML validity (13 SKILL.md) | PASS |
| `plugin.json` JSON validity | PASS |
| `references/*.md` link resolution (every cross-file ref in SKILL.md) | PASS |
| `examples/*.rs` link resolution | PASS |
| Acceptance: `rg 'x-authorizer-principalid' plugins/turul-mcp-skills` (excl. README changelog prose) | 0 matches |
| Acceptance: `rg 'SqliteTaskStorage::new\('` (excl. README) | 0 matches |
| Acceptance: `rg 'PostgresTaskStorage::new\('` (excl. README) | 0 matches |
| Acceptance: `rg 'DynamoDbTaskStorage::new\("'` (excl. README) | 0 matches |
| Smoke test compile + run | PASS |

## Smoke test

Throwaway crate at `/tmp/turul-skills-smoke` with path deps to the worktree. Exercised six distinct skills:

- **tool-creation-patterns**: `#[mcp_tool]` × 4 (`echo_text`, `add_numbers`, `server_time_stub`, `slow_add`) plus `#[derive(McpTool)]`
- **output-schemas**: `output = WordCount` with `schemars::JsonSchema` derive → `structuredContent` auto-generation
- **task-patterns**: `task_support = "optional"` attribute, `InMemoryTaskStorage::new()` constructor
- **resource-prompt-patterns**: `#[derive(McpResource)]` with `read()` impl
- **error-handling-patterns**: `McpError` variant constructors (`missing_param`, `invalid_param_type`, `tool_execution`, `resource_execution`, `validation`)
- **elicitation-workflows**: `ElicitationBuilder::new(...).string_field(...).require_fields(...).build()`

All patterns compiled cleanly against the worktree crate APIs and the resulting binary ran. No external services, no credentials, no cloud resources touched.

## Deferred follow-ups

Three documentation gaps surfaced by the smoke test that are **not** addressed in this PR (each suitable for a small future patch slice):

1. **`serde_json` is a required direct dependency for `#[mcp_tool]`.** The function macro expands to code referencing `serde_json::Value`, so consumer `Cargo.toml` must include `serde_json` directly. `tool-creation-patterns` does not currently mention this and should.
2. **`#[derive(McpTool)]` execute signature uses `Option<SessionContext>`.** The derive macro expects `impl T { async fn execute(&self, _session: Option<SessionContext>) -> McpResult<...> }`, not `&self` alone. `tool-creation-patterns` examples are inconsistent on this; canonicalising the signature would prevent the most common derive-macro compile error.
3. **`ElicitationBuilder` naming collision between `turul-mcp-builders` and `turul-mcp-protocol`.** Both crates export a type named `ElicitationBuilder` with different APIs. The skill correctly imports from `turul_mcp_builders`, but a user doing wildcard imports or relying on `prelude` could pull the wrong one. A "use `turul_mcp_builders`, not `turul_mcp_protocol`" callout in `elicitation-workflows` would prevent this.

`authorization-server-patterns` is intentionally left standalone in this PR (no demotion).