### PR TITLE
fix(http): return 400 for missing Mcp-Session-Id per MCP spec (v0.3.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -892,7 +892,8 @@ turul-mcp-server = { version = "0.3.27", features = ["sqlite"] }
 - AWS Lambda support
 - 42+ working examples
 
-[Unreleased]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.46...HEAD
+[Unreleased]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.47...HEAD
+[0.3.47]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.46...v0.3.47
 [0.3.46]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.45...v0.3.46
 [0.3.45]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.44...v0.3.45
 [0.3.44]: https://github.com/aussierobots/turul-mcp-framework/compare/v0.3.43...v0.3.44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.47] - 2026-05-23
+
+### Fixed
+
+- **`turul-http-mcp-server` returned HTTP 401 for missing `Mcp-Session-Id` instead of the spec-required HTTP 400.** MCP 2025-11-25 § Session Management states: *"Servers that require a session ID SHOULD respond to requests without an MCP-Session-Id header (other than initialization) with HTTP 400 Bad Request."* Two code paths were affected:
+  - **Streamable HTTP POST non-initialize, non-allowed-ping**: `crates/turul-http-mcp-server/src/streamable_http.rs:1347-1373` was returning `StatusCode::UNAUTHORIZED`. Now returns `StatusCode::BAD_REQUEST`. The pre-init ping bypass at line 1174 is preserved; with `allow_unauthenticated_ping=false`, sessionless ping rejection also lands in this path and correctly returns 400 (same missing-header contract). Stale comment at line 296 documenting the bug as if it were spec is corrected.
+  - **Legacy `session_handler.rs` GET SSE (protocol ≤ 2024-11-05)**: `crates/turul-http-mcp-server/src/session_handler.rs:864-870` was returning HTTP 200 with a JSON-RPC error body via `jsonrpc_error_to_unified_body` (which hardcodes 200). The JSON-RPC error body shape is preserved, but the response is now wrapped in a 400 status instead of 200. Cross-transport consistency with the Streamable HTTP path.
+- **Streamable HTTP GET and DELETE** were already returning 400 for missing session (`streamable_http.rs:546` and `:1083`); no code change needed on those paths — only their test assertions were tightened (the GET test was tolerant of either 400/401; now requires 400).
+- **Test compliance**: per CLAUDE.md §"Test Compliance" ("Tests validate the MCP spec — never change tests to preserve buggy behavior"), four test files were updated from asserting `401` to asserting `400`:
+  - `tests/session_id_compliance.rs` (6 assertions + 2 test renames + header comment)
+  - `tests/mcp_behavioral_compliance.rs` (sessionless-non-ping-rejected assertion, sessionless-ping-with-flag-off assertion, plus a new regression test for the legacy GET SSE missing-session path that pins both HTTP status and JSON-RPC envelope body)
+  - `tests/streamable_http_e2e.rs` (POST hard assertion + GET tightened-tolerant assertion + stale comments)
+  - `tests/phase5_regression_tests.rs` (line 136 assertion)
+- **CLAUDE.md §"Session Status Codes" table** updated to reflect the spec-correct mapping, including the ping/`allow_unauthenticated_ping` interaction and an explicit row for the legacy SSE path.
+
+### Versioning rule override
+
+This is an MCP transport contract correction. By the prior versioning rule ("Minor bumps cover A2A/MCP/schema contract changes") it would have been a minor (`0.4.0`) bump. We ship it as a patch (`0.3.47`) because:
+
+1. The change brings the framework into compliance with an existing spec, not adoption of a new spec revision; existing-spec compliance corrections are bug fixes by nature.
+2. The user-global versioning rule has been updated to: patch bumps cover bug fixes, contract corrections, and spec-compliance fixes; minor bumps are reserved for new MCP spec adoption or explicit instruction.
+3. Observable client impact is minimal: any conforming MCP 2025-11-25 client already handles 400 for missing session per spec; the prior 401 was a server-side defect that clients should already have been tolerant of (treating either 400 or 401 as "session is gone, restart `initialize`").
+
+### Revert-and-fail evidence
+
+After applying both fixes, reverting them via `git stash` and re-running the targeted tests produces:
+
+```
+test_sessionless_non_ping_rejected                                  left: 401, right: 400
+test_legacy_handler_get_sse_without_session_returns_400             left: 200, right: 400
+test_unauthenticated_ping_disabled_rejects_sessionless_ping         left: 401, right: 400
+test result: FAILED. 0 passed; 3 failed
+```
+
+Restoring the fix returns all 11 targeted tests to GREEN (8 `feature_tests` + 3 `compliance`). The test net catches both bug classes.
+
 ## [0.3.46] - 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,12 +209,15 @@ async fn count_words(text: String) -> McpResult<WordCount> {
 - **Without `Last-Event-ID`**: Fresh GET SSE stream. Server MAY send notifications. Replay policy for stored events is a deployment decision, not explicitly prohibited or required by the spec.
 - Event IDs are per-stream cursors. "The server MUST NOT replay messages that would have been delivered on a different stream."
 
-**Session Status Codes (Streamable HTTP):**
-- Missing `Mcp-Session-Id` header → **401** (no session ID provided at all)
+**Session Status Codes (Streamable HTTP):** (per MCP 2025-11-25 § Session Management)
+- Missing `Mcp-Session-Id` header → **400** ("Servers that require a session ID SHOULD respond to requests without an MCP-Session-Id header (other than initialization) with HTTP 400 Bad Request"). Pre-init `ping` bypass: with `allow_unauthenticated_ping = true` (default) sessionless pings succeed; with `false`, the rejection also returns 400 (same missing-header contract).
 - Nonexistent session ID → **404** (MCP spec: client must start fresh `initialize`)
 - Terminated session ID → **404** (MCP spec: treated same as nonexistent)
 - Auth token invalid/expired → **401** (OAuth middleware, separate from session)
+- Insufficient OAuth scope → **403**
 - Storage backend error → **500**
+
+**Legacy `session_handler.rs` (protocol ≤ 2024-11-05) GET SSE** also returns 400 for missing `Mcp-Session-Id` for cross-transport consistency (previously returned HTTP 200 with a JSON-RPC error body — non-spec).
 
 **Testing:** All requests need valid Accept header (application/json, text/event-stream, or */*)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.46"
+version = "0.3.47"
 edition = "2024"
 authors = ["Nick Hortovanyi <nick@aussierobots.com.au>"]
 license = "MIT OR Apache-2.0"
@@ -149,20 +149,20 @@ bytes = "1"
 turul-rpc = { version = "0.1", default-features = false }
 
 # Internal crate dependencies
-turul-mcp-json-rpc-server = { version = "0.3.46", path = "crates/turul-mcp-json-rpc-server" }
-turul-mcp-protocol-2025-06-18 = { version = "0.3.46", path = "crates/turul-mcp-protocol-2025-06-18" }
-turul-mcp-protocol-2025-11-25 = { version = "0.3.46", path = "crates/turul-mcp-protocol-2025-11-25" }
-turul-mcp-protocol = { version = "0.3.46", path = "crates/turul-mcp-protocol" }
-turul-mcp-session-storage = { version = "0.3.46", path = "crates/turul-mcp-session-storage" }
-turul-mcp-task-storage = { version = "0.3.46", path = "crates/turul-mcp-task-storage" }
-turul-mcp-server-state-storage = { version = "0.3.46", path = "crates/turul-mcp-server-state-storage" }
-turul-http-mcp-server = { version = "0.3.46", path = "crates/turul-http-mcp-server" }
-turul-mcp-server = { version = "0.3.46", path = "crates/turul-mcp-server" }
-turul-mcp-derive = { version = "0.3.46", path = "crates/turul-mcp-derive" }
-turul-mcp-client = { version = "0.3.46", path = "crates/turul-mcp-client" }
-turul-mcp-builders = { version = "0.3.46", path = "crates/turul-mcp-builders" }
-turul-mcp-aws-lambda = { version = "0.3.46", path = "crates/turul-mcp-aws-lambda" }
-turul-mcp-oauth = { version = "0.3.46", path = "crates/turul-mcp-oauth" }
+turul-mcp-json-rpc-server = { version = "0.3.47", path = "crates/turul-mcp-json-rpc-server" }
+turul-mcp-protocol-2025-06-18 = { version = "0.3.47", path = "crates/turul-mcp-protocol-2025-06-18" }
+turul-mcp-protocol-2025-11-25 = { version = "0.3.47", path = "crates/turul-mcp-protocol-2025-11-25" }
+turul-mcp-protocol = { version = "0.3.47", path = "crates/turul-mcp-protocol" }
+turul-mcp-session-storage = { version = "0.3.47", path = "crates/turul-mcp-session-storage" }
+turul-mcp-task-storage = { version = "0.3.47", path = "crates/turul-mcp-task-storage" }
+turul-mcp-server-state-storage = { version = "0.3.47", path = "crates/turul-mcp-server-state-storage" }
+turul-http-mcp-server = { version = "0.3.47", path = "crates/turul-http-mcp-server" }
+turul-mcp-server = { version = "0.3.47", path = "crates/turul-mcp-server" }
+turul-mcp-derive = { version = "0.3.47", path = "crates/turul-mcp-derive" }
+turul-mcp-client = { version = "0.3.47", path = "crates/turul-mcp-client" }
+turul-mcp-builders = { version = "0.3.47", path = "crates/turul-mcp-builders" }
+turul-mcp-aws-lambda = { version = "0.3.47", path = "crates/turul-mcp-aws-lambda" }
+turul-mcp-oauth = { version = "0.3.47", path = "crates/turul-mcp-oauth" }
 
 # Additional dependencies for examples and tests
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/turul-http-mcp-server/src/session_handler.rs
+++ b/crates/turul-http-mcp-server/src/session_handler.rs
@@ -857,7 +857,13 @@ impl SessionMcpHandler {
             protocol_version, session_id
         );
 
-        // Session ID is required for SSE
+        // Session ID is required for SSE.
+        // Per MCP 2025-11-25 § Session Management: missing Mcp-Session-Id → HTTP 400 Bad Request.
+        // Mirrors the streamable_http.rs POST pattern: build the JSON-RPC error body via the
+        // standard `JsonRpcError` helper, then wrap it in a 400 response. (The
+        // `jsonrpc_error_to_unified_body` helper hardcodes HTTP 200, which was non-spec here;
+        // we keep the JSON-RPC body shape but inline the response builder to set the correct
+        // status.)
         let session_id = match session_id {
             Some(id) => id,
             None => {
@@ -866,7 +872,12 @@ impl SessionMcpHandler {
                     None,
                     JsonRpcErrorObject::server_error(-32002, "Missing Mcp-Session-Id header", None),
                 );
-                return jsonrpc_error_to_unified_body(error);
+                let error_json = serde_json::to_string(&error).unwrap_or_else(|_| "{}".to_string());
+                return Ok(Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(convert_to_unified_body(Full::new(Bytes::from(error_json))))
+                    .unwrap());
             }
         };
 

--- a/crates/turul-http-mcp-server/src/streamable_http.rs
+++ b/crates/turul-http-mcp-server/src/streamable_http.rs
@@ -292,8 +292,10 @@ impl StreamableHttpContext {
 
 /// Why session validation failed — determines the HTTP status code.
 ///
-/// MCP 2025-11-25 spec: terminated or unknown sessions MUST return 404 Not Found.
-/// Missing `Mcp-Session-Id` header (a different code path) stays 401 Unauthorized.
+/// MCP 2025-11-25 § Session Management:
+/// - Missing `Mcp-Session-Id` header (different code path, see POST handler) → 400 Bad Request
+/// - Terminated or unknown session ID → 404 Not Found (MUST)
+/// - Auth failures (OAuth middleware, different layer) → 401 Unauthorized
 enum SessionValidationError {
     /// Session ID not found or session has been terminated → 404 Not Found
     NotFound(String),
@@ -1344,8 +1346,14 @@ impl StreamableHttpHandler {
                     }
                     existing_id.clone()
                 } else {
-                    // Return 401 for missing header — this is NOT a stale session (404),
-                    // it's "no session ID provided at all"
+                    // Per MCP 2025-11-25 § Session Management: "Servers that require a session ID
+                    // SHOULD respond to requests without an MCP-Session-Id header (other than
+                    // initialization) with HTTP 400 Bad Request." This covers non-initialize,
+                    // non-allowed-ping requests. The pre-init ping bypass at the top of this
+                    // function still applies; with allow_unauthenticated_ping=false the ping
+                    // rejection also lands here and correctly returns 400.
+                    // Stale sessions are a different code path (→ 404). Auth failures live in
+                    // OAuth middleware (→ 401).
                     let method_name = match &message {
                         JsonRpcMessage::Request(req) => &req.method,
                         JsonRpcMessage::Notification(notif) => &notif.method,
@@ -1370,7 +1378,7 @@ impl StreamableHttpHandler {
                         serde_json::to_string(&error_response).unwrap_or_else(|_| "{}".to_string());
 
                     return Response::builder()
-                        .status(StatusCode::UNAUTHORIZED)
+                        .status(StatusCode::BAD_REQUEST)
                         .header(CONTENT_TYPE, "application/json")
                         .header("MCP-Protocol-Version", context.protocol_version.as_str())
                         .body(

--- a/examples/archived/calculator-add-simple-server/src/main.rs
+++ b/examples/archived/calculator-add-simple-server/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting calculator_add_simple server (Level 1)");
     let server = McpServer::builder()
         .name("calculator_add_simple")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Add Simple Server")
         .instructions("Add two numbers using ultra-simple function macros (Level 1 - Zero Configuration)")
         .tool_fn(calculator_add)  // Framework auto-determines method from function name

--- a/examples/archived/calculator-struct-output-example/src/main.rs
+++ b/examples/archived/calculator-struct-output-example/src/main.rs
@@ -250,7 +250,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting calculator struct output example server");
     let server = McpServer::builder()
         .name("calculator_struct_output")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Struct Output Example Server")
         .instructions("Demonstrates struct-based output_type with derive macros for complex calculation results")
         .tool(CalculatorStructTool {

--- a/examples/archived/comprehensive-types-example/src/main.rs
+++ b/examples/archived/comprehensive-types-example/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting comprehensive types example server");
     let server = McpServer::builder()
         .name("comprehensive_types_example")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Comprehensive Types Example Server")
         .instructions("Demonstrates various parameter and output types for MCP tools")
         .tool(MathOperationsTool {

--- a/examples/archived/mixed-approaches-example/src/main.rs
+++ b/examples/archived/mixed-approaches-example/src/main.rs
@@ -255,7 +255,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting mixed approaches example server");
     let server = McpServer::builder()
         .name("mixed_approaches_example")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Mixed Approaches Example Server")
         .instructions("Demonstrates both derive macro and manual trait implementation approaches")
         .tool(EchoDeriveTool {

--- a/examples/calculator-add-builder-server/src/main.rs
+++ b/examples/calculator-add-builder-server/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("calculator_add_builder")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Add Builder Server")
         .instructions("Add two numbers using builder pattern (Level 3 - Runtime Flexibility)")
         .tool(add_tool)

--- a/examples/calculator-add-function-server/src/main.rs
+++ b/examples/calculator-add-function-server/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("calculator_add_function")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Add Function Server")
         .instructions("Add two numbers using function macro (Level 1 - Ultra Simple)")
         .tool_fn(calculator_add) // Perfect! Use the original function name

--- a/examples/calculator-add-manual-server/src/main.rs
+++ b/examples/calculator-add-manual-server/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting calculator_add_manual server (Level 4)");
     let server = McpServer::builder()
         .name("calculator_add_manual")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Add Manual Server")
         .instructions(
             "Add two numbers using fully manual implementation (Level 4 - Maximum Control)",

--- a/examples/calculator-add-simple-server-derive/src/main.rs
+++ b/examples/calculator-add-simple-server-derive/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting calculator_add_derive server");
     let server = McpServer::builder()
         .name("calculator_add_derive")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Calculator Add Derive Server")
         .instructions("Add two numbers using derive macro (Level 2)")
         .tool(CalculatorAddDeriveTool { a: 0.0, b: 0.0 })

--- a/examples/oauth-resource-server/src/main.rs
+++ b/examples/oauth-resource-server/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> McpResult<()> {
 
     let mut builder = McpServer::builder()
         .name("oauth-resource-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("OAuth 2.1 Resource Server Example")
         .instructions(
             "This server requires a valid Bearer token from the configured \

--- a/examples/prompts-test-server/src/main.rs
+++ b/examples/prompts-test-server/src/main.rs
@@ -877,7 +877,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("prompts-test-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("MCP Prompts Test Server")
         .instructions(
             "Comprehensive test server providing various types of prompts for E2E testing.\n\

--- a/examples/resource-test-server/src/main.rs
+++ b/examples/resource-test-server/src/main.rs
@@ -1603,7 +1603,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("resource-test-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("MCP Resource Test Server")
         .instructions(
             "Comprehensive test server providing various types of resources for E2E testing.\n\

--- a/examples/roots-server/src/main.rs
+++ b/examples/roots-server/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("roots-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("MCP Roots Test Server")
         .instructions("Test server demonstrating MCP roots functionality for file system access control and directory discovery. Provides root directories for E2E testing.")
         // Add root directories the server can access

--- a/examples/session-aware-resource-server/src/main.rs
+++ b/examples/session-aware-resource-server/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("session-aware-resource-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("Session-Aware Resource Server")
         .instructions("This server demonstrates Phase 6 session-aware resources. Resources can access session context to provide personalized content based on user state and preferences.")
         .resource(SessionAwareProfileResource)

--- a/examples/tasks-e2e-inmemory-server/src/main.rs
+++ b/examples/tasks-e2e-inmemory-server/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server = McpServer::builder()
         .name("tasks-e2e-inmemory-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .with_task_storage(Arc::new(InMemoryTaskStorage::new()))
         .tool_fn(slow_add)
         .tool_fn(slow_cancelable)

--- a/examples/tool-output-introspection/src/main.rs
+++ b/examples/tool-output-introspection/src/main.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create server with tools using struct introspection
     let server = McpServer::builder()
         .name("tool-output-introspection-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .tool(Calculator::default())
         .tool(TempConverter::default())
         .build()?;

--- a/examples/tool-output-schemas/src/main.rs
+++ b/examples/tool-output-schemas/src/main.rs
@@ -190,7 +190,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create server with tools that use schemars
     let server = McpServer::builder()
         .name("tool-output-schemas-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .tool(CalculatorDeriveTool::default())
         .tool(add_numbers())
         .tool(AnalyzeDataTool::default())

--- a/examples/tools-test-server/src/main.rs
+++ b/examples/tools-test-server/src/main.rs
@@ -855,7 +855,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create server with comprehensive tool collection (with strict lifecycle for testing)
     let server = McpServer::builder()
         .name("tools-test-server")
-        .version("0.3.46")
+        .version("0.3.47")
         .title("MCP Tools Test Server")
         .instructions("Comprehensive test tools for E2E validation")
         .with_strict_lifecycle() // Enable strict lifecycle enforcement for E2E testing

--- a/tests/mcp_behavioral_compliance.rs
+++ b/tests/mcp_behavioral_compliance.rs
@@ -806,7 +806,7 @@ async fn test_strict_lifecycle_rejects_tool_calls_before_initialized() {
 // The key evidence that streamable HTTP enforcement works:
 // 1. SessionAwareMcpHandlerBridge.handle() and handle_notification() both include lifecycle checks
 // 2. All requests (regular and streamable) go through the same dispatcher.register_handler() system
-// 3. The failing E2E tests in streamable_http_e2e.rs show 401 errors, proving enforcement is active
+// 3. The failing E2E tests in streamable_http_e2e.rs show 400 errors, proving enforcement is active
 // 4. Both test_strict_lifecycle_allows_after_initialized and test_strict_lifecycle_rejects_before_initialized
 //    demonstrate the lifecycle enforcement logic works correctly
 //
@@ -1152,7 +1152,7 @@ async fn test_sessionless_ping_notification_returns_202() {
 /// T3: Pre-init non-ping request rejected
 ///
 /// All methods other than `ping` require a valid Mcp-Session-Id header.
-/// Without one, the server should return 401.
+/// Without one, the server should return 400 per MCP 2025-11-25 § Session Management.
 #[tokio::test]
 async fn test_sessionless_non_ping_rejected() {
     let server_url = start_test_server_with_tools().await;
@@ -1176,8 +1176,8 @@ async fn test_sessionless_non_ping_rejected() {
 
     assert_eq!(
         response.status(),
-        401,
-        "Non-ping request without session should be rejected with 401"
+        400,
+        "Non-ping request without session should be rejected with 400 per MCP spec"
     );
 }
 
@@ -1218,7 +1218,8 @@ async fn test_post_init_ping_with_session_works() {
 /// T5: allow_unauthenticated_ping=false restores rejection
 ///
 /// When the config opt-out is set, sessionless ping should be rejected
-/// with 401, restoring the original strict behavior.
+/// with 400 (same missing-session contract as any other non-ping method),
+/// restoring strict behavior. Per MCP 2025-11-25 § Session Management.
 #[tokio::test]
 async fn test_unauthenticated_ping_disabled_rejects_sessionless_ping() {
     let server_url = start_test_server_no_unauthenticated_ping().await;
@@ -1241,8 +1242,8 @@ async fn test_unauthenticated_ping_disabled_rejects_sessionless_ping() {
 
     assert_eq!(
         response.status(),
-        401,
-        "Sessionless ping should be 401 when allow_unauthenticated_ping=false"
+        400,
+        "Sessionless ping should be 400 when allow_unauthenticated_ping=false per MCP spec"
     );
 }
 
@@ -1283,6 +1284,69 @@ async fn test_legacy_handler_sessionless_ping_works() {
     assert!(
         body["result"].is_object(),
         "Legacy ping should return empty result object"
+    );
+}
+
+/// Legacy handler GET SSE without session → 400 + JSON-RPC error envelope.
+///
+/// Regression guard for session_handler.rs GET SSE missing-session path.
+/// Previously returned HTTP 200 with a JSON-RPC error body (non-spec).
+/// Now returns HTTP 400 per MCP 2025-11-25 § Session Management while preserving
+/// the JSON-RPC 2.0 error envelope in the body. This test pins BOTH the HTTP
+/// status AND the body schema so a future refactor that swaps either dimension
+/// (e.g. back to `jsonrpc_error_to_unified_body` which hardcodes 200, or to an
+/// ad-hoc `{"error":{"code":400,...}}` body without the `jsonrpc` field) will
+/// fail immediately.
+#[tokio::test]
+async fn test_legacy_handler_get_sse_without_session_returns_400() {
+    let server_url = start_test_server_with_tools().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(&server_url)
+        .header("Accept", "text/event-stream")
+        .header("MCP-Protocol-Version", "2024-11-05")
+        .send()
+        .await
+        .unwrap();
+
+    // Wire-layer contract: HTTP 400 + application/json + JSON-RPC 2.0 envelope.
+    assert_eq!(
+        response.status(),
+        400,
+        "Legacy GET SSE without session should return HTTP 400 (was 200+JSON-RPC error)"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or(""),
+        "application/json",
+        "Body should be JSON-encoded JSON-RPC error envelope"
+    );
+
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(
+        body["jsonrpc"], "2.0",
+        "Body MUST be a JSON-RPC 2.0 envelope (preserves contract for MCP clients)"
+    );
+    assert!(
+        body["id"].is_null(),
+        "id MUST be null per JSON-RPC 2.0 §5 (request id was un-parseable: missing header is pre-dispatch)"
+    );
+    assert!(
+        body["error"].is_object(),
+        "envelope MUST have an `error` object"
+    );
+    assert_eq!(
+        body["error"]["code"], -32002,
+        "error.code locked at -32002 for missing-session on the legacy path"
+    );
+    let msg = body["error"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("Missing Mcp-Session-Id"),
+        "error.message should explain the missing-header condition, got: {msg}"
     );
 }
 

--- a/tests/phase5_regression_tests.rs
+++ b/tests/phase5_regression_tests.rs
@@ -133,7 +133,7 @@ async fn test_lifecycle_enforcement_over_streamable_http() {
             .send()
     ).await.expect("Request timeout").expect("Request failed");
 
-    assert_eq!(response.status(), 401); // Should be unauthorized without session
+    assert_eq!(response.status(), 400); // Missing session → 400 per MCP 2025-11-25 § Session Management
 }
 
 /// Test pagination limit bounds

--- a/tests/session_id_compliance.rs
+++ b/tests/session_id_compliance.rs
@@ -1,8 +1,12 @@
 //! Integration tests for MCP session ID compliance
 //!
 //! Verifies that:
-//! - Only `initialize` works without session ID
-//! - All other methods return 401 without session ID
+//! - Only `initialize` (and sessionless `ping` when allowed) work without session ID
+//! - All other methods return 400 Bad Request without session ID per MCP 2025-11-25
+//!   § Session Management ("Servers that require a session ID SHOULD respond ... with
+//!   HTTP 400 Bad Request")
+//! - Nonexistent or terminated session IDs return 404 (different code path)
+//! - 401 is reserved for auth-layer failures (missing/invalid bearer)
 //! - Session ID is properly passed through the handshake
 
 use serde_json::{Value, json};
@@ -52,11 +56,11 @@ async fn start_test_server() -> String {
 }
 
 #[tokio::test]
-async fn test_tools_list_without_session_returns_401() {
+async fn test_tools_list_without_session_returns_400() {
     let server_url = start_test_server().await;
     let client = reqwest::Client::new();
 
-    // Try tools/list WITHOUT session ID - should return 401
+    // Try tools/list WITHOUT session ID - should return 400 per MCP 2025-11-25
     let response = client
         .post(&server_url)
         .header("Content-Type", "application/json")
@@ -70,9 +74,12 @@ async fn test_tools_list_without_session_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), 401);
-
+    // Wire-layer contract: HTTP 400 + JSON-RPC 2.0 envelope body.
+    // Pinning both dimensions so a future refactor cannot quietly drop the
+    // `jsonrpc: "2.0"` field or revert the status to 401/200 without failing here.
+    assert_eq!(response.status(), 400);
     let body: Value = response.json().await.unwrap();
+    assert_eq!(body["jsonrpc"], "2.0", "MUST be a JSON-RPC 2.0 envelope");
     assert_eq!(body["error"]["code"], -32001);
     assert!(
         body["error"]["message"]
@@ -83,11 +90,11 @@ async fn test_tools_list_without_session_returns_401() {
 }
 
 #[tokio::test]
-async fn test_resources_list_without_session_returns_401() {
+async fn test_resources_list_without_session_returns_400() {
     let server_url = start_test_server().await;
     let client = reqwest::Client::new();
 
-    // Try resources/list WITHOUT session ID - should return 401
+    // Try resources/list WITHOUT session ID - should return 400 per MCP 2025-11-25
     let response = client
         .post(&server_url)
         .header("Content-Type", "application/json")
@@ -101,7 +108,7 @@ async fn test_resources_list_without_session_returns_401() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), 401);
+    assert_eq!(response.status(), 400);
 
     let body: Value = response.json().await.unwrap();
     assert_eq!(body["error"]["code"], -32001);
@@ -211,7 +218,7 @@ async fn test_discovery_methods_with_session_succeed() {
     // Should contain result, not error
     let body_text = tools_response.text().await.unwrap();
     // We don't check the exact result since it's streamed, just that we get a response
-    // The key test is that we get 200 OK instead of 401 Unauthorized
+    // The key test is that we get 200 OK instead of 400 Bad Request (missing session)
     assert!(!body_text.is_empty(), "Response should not be empty");
 }
 
@@ -220,7 +227,7 @@ async fn test_complete_session_flow() {
     let server_url = start_test_server().await;
     let client = reqwest::Client::new();
 
-    // Step 1: tools/list without session should fail with 401
+    // Step 1: tools/list without session should fail with 400
     let no_session_response = client
         .post(&server_url)
         .header("Content-Type", "application/json")
@@ -234,7 +241,7 @@ async fn test_complete_session_flow() {
         .await
         .unwrap();
 
-    assert_eq!(no_session_response.status(), 401);
+    assert_eq!(no_session_response.status(), 400);
 
     // Step 2: Initialize to get session
     let init_response = client
@@ -414,7 +421,7 @@ async fn test_mcp_inspector_flow_with_combined_accept_header() {
 }
 
 /// MCP 2025-11-25 spec: a fabricated/nonexistent session ID must return 404 Not Found,
-/// NOT 401 Unauthorized. 401 is reserved for auth failures; 404 tells the client
+/// NOT 400 (missing header) or 401 (auth failure). 404 tells the client
 /// to start a fresh initialize handshake.
 #[tokio::test]
 async fn test_nonexistent_session_returns_404() {
@@ -439,7 +446,7 @@ async fn test_nonexistent_session_returns_404() {
     assert_eq!(
         response.status(),
         404,
-        "Nonexistent session must return 404 per MCP spec, not 401"
+        "Nonexistent session must return 404 per MCP spec (not 400 missing-header, not 401 auth)"
     );
 }
 
@@ -493,7 +500,7 @@ async fn test_terminated_session_returns_404() {
         delete_response.status()
     );
 
-    // Step 3: Use the terminated session — must get 404, not 401
+    // Step 3: Use the terminated session — must get 404, not 400/401
     let stale_response = client
         .post(&server_url)
         .header("Content-Type", "application/json")
@@ -511,6 +518,6 @@ async fn test_terminated_session_returns_404() {
     assert_eq!(
         stale_response.status(),
         404,
-        "Terminated session must return 404 per MCP spec, not 401"
+        "Terminated session must return 404 per MCP spec (not 400 missing-header, not 401 auth)"
     );
 }

--- a/tests/streamable_http_e2e.rs
+++ b/tests/streamable_http_e2e.rs
@@ -1422,11 +1422,11 @@ async fn test_negative_cases_missing_headers() {
         .expect("Request timeout")
         .expect("Request failed");
 
-    // Should return 401 for missing session ID (unauthorized)
+    // Should return 400 for missing session ID per MCP 2025-11-25 § Session Management
     assert_eq!(
         response.status(),
-        StatusCode::UNAUTHORIZED,
-        "POST without session ID should return 401"
+        StatusCode::BAD_REQUEST,
+        "POST without session ID should return 400 per MCP spec"
     );
 
     let error_body = response.into_body().collect().await.unwrap().to_bytes();
@@ -1460,11 +1460,11 @@ async fn test_negative_cases_missing_headers() {
         .expect("Request timeout")
         .expect("Request failed");
 
-    // Should fail without session
-    assert!(
-        response.status() == StatusCode::UNAUTHORIZED
-            || response.status() == StatusCode::BAD_REQUEST,
-        "GET without session ID should fail, got: {}",
+    // Should fail with 400 per MCP 2025-11-25 § Session Management
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "GET without session ID should return 400 per MCP spec, got: {}",
         response.status()
     );
     println!("✅ GET without session ID properly rejected");
@@ -1692,8 +1692,8 @@ async fn test_strict_lifecycle_enforcement_over_streamable_http() {
     let client = create_client();
     let base_url = format!("http://127.0.0.1:{}", server.port());
 
-    // Test: Request without proper session initialization should fail
-    // In streamable HTTP, this returns 401 status (vs JSON-RPC error in regular HTTP)
+    // Test: Request with a nonexistent session ID should fail with 404
+    // (a different code path than missing-header, which would be 400)
     let unauthorized_request = Request::builder()
         .method(Method::POST)
         .uri(format!("{}/mcp", base_url))
@@ -1718,7 +1718,7 @@ async fn test_strict_lifecycle_enforcement_over_streamable_http() {
         .expect("Request failed");
 
     // MCP 2025-11-25 spec: nonexistent session ID → 404 Not Found
-    // (not 401 — that's for missing auth tokens, not stale sessions)
+    // (not 400 — that's missing-header; not 401 — that's auth failure)
     assert_eq!(
         response.status(),
         StatusCode::NOT_FOUND,


### PR DESCRIPTION
## Scope

**Framework spec-compliance fix.** Two server-side code paths corrected to comply with [MCP 2025-11-25 § Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management): *"Servers that require a session ID SHOULD respond to requests without an `MCP-Session-Id` header (other than initialization) with HTTP 400 Bad Request."* Plus the matching test and docs updates.

Patch release `v0.3.47` (rationale below).

Commits:
- `0969bdb` — `fix(http): return 400 for missing Mcp-Session-Id per MCP spec (v0.3.47)`
- `5a6f389` — `docs(changelog): add v0.3.47 footer compare links`

## What changed

### Code (2 sites — both in `turul-http-mcp-server`)

| Path | Before | After |
|---|---|---|
| `streamable_http.rs:1347-1373` — POST non-initialize, non-allowed-ping, missing session | `401 Unauthorized` + JSON-RPC error envelope | `400 Bad Request` + same JSON-RPC error envelope |
| `session_handler.rs:864-880` — legacy GET SSE (protocol ≤ 2024-11-05), missing session | `200 OK` + JSON-RPC error envelope (via `jsonrpc_error_to_unified_body` which hardcodes 200) | `400 Bad Request` + same JSON-RPC error envelope (inlined builder so the status can be set correctly) |

**Pre-init ping bypass at `streamable_http.rs:1174` preserved**: with `allow_unauthenticated_ping = true` (default, per MCP Lifecycle) sessionless pings succeed; with `false`, the rejection now lands in the patched path and correctly returns `400` (same missing-header contract).

**Streamable HTTP GET and DELETE missing-session paths were already returning 400** — no code change there; only test assertions tightened.

**Stale comment at `streamable_http.rs:296`** (which documented the buggy 401 as if it were spec) replaced with a three-line summary citing the spec.

### Tests (4 files, per CLAUDE.md §"Test Compliance")

- `tests/session_id_compliance.rs` — 6 assertion flips, 2 test renames, header comment updated.
- `tests/mcp_behavioral_compliance.rs` — sessionless-non-ping-rejected assertion, sessionless-ping-with-flag-off assertion, plus a **new regression test** for the legacy GET SSE missing-session path that pins **both** HTTP status (400) **and** JSON-RPC envelope body shape (`jsonrpc:"2.0"`, `error.code`, `error.message`) so a future refactor cannot drift either dimension silently.
- `tests/streamable_http_e2e.rs` — POST hard assertion tightened, GET tolerant-assertion tightened to require exactly `400`, two stale comments fixed.
- `tests/phase5_regression_tests.rs` — line 136 assertion flipped.

### Docs

- `CLAUDE.md` § "Session Status Codes (Streamable HTTP)" — table now reflects the spec-correct mapping (400 / 404 / 401 / 403 / 500) plus an explicit row for the legacy GET SSE path.
- `CHANGELOG.md` — `## [0.3.47]` entry with full spec citation, scope, revert-and-fail evidence, and the versioning-rule override rationale. Footer compare links added in `5a6f389` (the historical drift pattern documented in repo memory caught me on the initial commit; second commit fixes it).

### Version

`v0.3.46 → v0.3.47` across workspace `Cargo.toml` (workspace + 14 internal dep refs) and 17 example `main.rs` `.version("...")` strings.

## Validation

| Check | Scope | Result |
|---|---|---|
| RED test pre-fix | Targeted (3 tests) | All fail with expected `left:401/200, right:400` |
| GREEN test post-fix | Targeted (11 tests) | All pass |
| Revert-and-fail proof | `git stash` of code fix → re-run | 3 expected failures: `401→400`, `200→400`, `401→400`. Restoring fix returns 257 targeted tests to GREEN. |
| Full targeted sweep | `--test compliance --test feature_tests --test e2e_tests` | **257 passed, 0 failed, 2 ignored** |
| `cargo fmt --check` (touched crates) | `-p turul-http-mcp-server -p turul-mcp-framework-integration-tests` | ✅ passes (0 drift) |
| **`cargo fmt --check` (full workspace)** | unrestricted | ⚠️ **fails on pre-existing drift in `crates/turul-mcp-client/src/client.rs` and `crates/turul-mcp-client/tests/wire_compliance.rs`** — both files are **untouched by this PR** and the drift is present on `main`. Not introduced by this slice. If CI gates on workspace fmt, expect failure; addressing it is out of scope for this spec-compliance slice and would be its own cleanup PR. |

## Versioning rule override (documented)

By the prior rule ("Minor bumps cover A2A/MCP/schema contract changes") this would have been `v0.4.0`. Shipped as patch `v0.3.47` because:

1. The change brings the framework into compliance with an **existing** spec, not adoption of a new spec revision.
2. The user-global versioning rule has been updated to: patch bumps cover bug fixes, contract corrections, and spec-compliance fixes; minor bumps are reserved for new MCP spec adoption or explicit instruction.
3. Observable client impact is minimal: any conforming MCP 2025-11-25 client already handles `400` for missing session per spec; the prior `401` was a server-side defect.

## Drift-prevention pattern (introduced; reusable)

The new regression test for legacy GET SSE pins 5 dimensions of the wire contract: HTTP status + `Content-Type` + `jsonrpc:"2.0"` field + JSON-RPC `error.code` + JSON-RPC `error.message` substring. This is exactly what CLAUDE.md §"Test Compliance" mandates and is now codified for this missing-header path. Recommend the same pattern for other wire-layer tests when they're touched.

## Follow-up items deferred (out of scope for this PR)

Three observations from the implementation that are **not** addressed here:

1. **`jsonrpc_error_to_unified_body` is an attractive nuisance.** The helper hardcodes HTTP 200 — correct for application-level JSON-RPC errors, wrong for transport-level ones. Recommend a sibling `jsonrpc_error_with_status(error, status)` so "use the helper" becomes safe for both cases. Small future patch.
2. **JSON-RPC error code inconsistency between the two paths.** Streamable POST uses `-32001` ("Missing Mcp-Session-Id header. Call initialize first."); legacy GET SSE uses `-32002` ("Missing Mcp-Session-Id header"). Same logical condition, different application-defined codes. Worth converging on `-32001` (more actionable message).
3. **Drift-prevention pattern propagation.** Most existing wire-layer tests assert only 1-2 of the 5 dimensions above. As tests are touched in future work, tighten them to the full 5-dimension pattern.